### PR TITLE
Add GitHub Actions to Squiggle Lang

### DIFF
--- a/.github/workflows/lang-jest.yml
+++ b/.github/workflows/lang-jest.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Install Packages
       run: yarn 
     - name: Build rescript
-      run: yarn recsript build -with-deps
+      run: yarn rescript build -with-deps
     - name: Run tests
       run: yarn test

--- a/.github/workflows/lang-jest.yml
+++ b/.github/workflows/lang-jest.yml
@@ -13,5 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Packages
       run: yarn 
+    - name: Build rescript
+      run: yarn recsript build -with-deps
     - name: Run tests
       run: yarn test

--- a/.github/workflows/lang-jest.yml
+++ b/.github/workflows/lang-jest.yml
@@ -5,9 +5,10 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    run:
-      shell: bash
-      working-directory: packages/squiggle-lang
+    defaults:
+      run:
+        shell: bash
+        working-directory: packages/squiggle-lang
     steps:
     - uses: actions/checkout@v2
     - name: Install Packages

--- a/.github/workflows/lang-jest.yml
+++ b/.github/workflows/lang-jest.yml
@@ -1,0 +1,16 @@
+name: Squiggle Lang Jest Tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    run:
+      shell: bash
+      working-directory: packages/squiggle-lang
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Packages
+      run: yarn 
+    - name: Run tests
+      run: yarn test


### PR DESCRIPTION
Simply using GitHub actions to run Jest over Squiggle Lang. The tests currently fail, and will fail until #22 is merged, because of a couple of files that have no tests in them.