### PR TITLE
Allow settings to be edited by component users

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -22,5 +22,14 @@ module.exports = {
   "framework": "@storybook/react",
   "core": {
     "builder": "webpack5"
-  }
+  },
+  typescript: {
+    check: false,
+    checkOptions: {},
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: (prop) => (prop.parent ? !/node_modules/.test(prop.parent.fileName) : true),
+    },
+  },
 }

--- a/packages/components/src/stories/SquiggleChart.stories.mdx
+++ b/packages/components/src/stories/SquiggleChart.stories.mdx
@@ -1,9 +1,9 @@
 import { SquiggleChart } from '../SquiggleChart'
-import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Canvas, Meta, Story, Props } from '@storybook/addon-docs';
 
 <Meta title="Squiggle/SquiggleChart" component={ SquiggleChart } />
 
-export const Template = ({squiggleString}) => <SquiggleChart squiggleString={squiggleString} />
+export const Template = SquiggleChart
 
 # Squiggle Chart
 
@@ -79,3 +79,4 @@ over the axis between x = 0 and 10.
   </Story>
 </Canvas>
 
+<Props of={SquiggleChart} />

--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -1,3 +1,15 @@
 import {runAll} from '../rescript/ProgramEvaluator.gen';
+import type { Inputs_SamplingInputs_t as SamplingInputs } from '../rescript/ProgramEvaluator.gen';
+export type { SamplingInputs } 
 export type {t as DistPlus} from '../rescript/pointSetDist/DistPlus.gen';
-export let run = runAll
+
+export let defaultSamplingInputs : SamplingInputs = {
+  sampleCount : 10000,
+  outputXYPoints : 10000,
+  pointDistLength : 1000
+}
+
+export function run(squiggleString : string, samplingInputs? : SamplingInputs) {
+  let si : SamplingInputs = samplingInputs ? samplingInputs : defaultSamplingInputs
+  return runAll(squiggleString, si)
+}

--- a/packages/squiggle-lang/src/rescript/ProgramEvaluator.res
+++ b/packages/squiggle-lang/src/rescript/ProgramEvaluator.res
@@ -193,14 +193,9 @@ let evaluateProgram = (inputs: Inputs.inputs) =>
 
 
 @genType
-let runAll = (squiggleString: string) => {
+let runAll = (squiggleString: string, samplingInputs: Inputs.SamplingInputs.t) => {
   let inputs = Inputs.make(
-    ~samplingInputs={
-      sampleCount: Some(10000),
-      outputXYPoints: Some(10000),
-      kernelWidth: None,
-      pointDistLength: Some(1000),
-    },
+    ~samplingInputs,
     ~squiggleString,
     ~environment=[]->Belt.Map.String.fromArray,
     (),


### PR DESCRIPTION
Sampling and function settings were hardcoded for Squiggle executions, this PR allows people to set their own settings if they chose. It also falls back on default settings if the user doesn't want to specify any.

I'm doing this with the motivation of plugging the playground settings into the components.