### PR TITLE
Fix mm crashing on too many weights

### DIFF
--- a/packages/squiggle-lang/__tests__/JS__Test.ts
+++ b/packages/squiggle-lang/__tests__/JS__Test.ts
@@ -2,14 +2,18 @@ import { run } from '../src/js/index';
 
 describe("A simple result", () => {
     test("mean(normal(5,2))", () => {
-        expect(run("mean(normal(5,2))")).toEqual({ tag: 'Ok', value: [ { NAME: 'Float', VAL: 5  } ] });
-    });
+        expect(run("mean(normal(5,2))")).toEqual({ tag: 'Ok', value: [ { NAME: 'Float', VAL: 5  } ] })
+    })
     test("10+10", () => {
-        let foo = run("normal(5,2)");
-        expect(1).toEqual(1);
-    });
+        let foo = run("10 + 10")
+        expect(foo).toEqual({ tag: 'Ok', value: [ { NAME: 'Float', VAL: 20  } ] })
+    })
     test("log(1) = 0", () => {
-      let foo = run("log(1)");
-      expect(foo).toEqual({ tag: 'Ok', value: [ { NAME: 'Float', VAL: 0} ]});
+      let foo = run("log(1)")
+      expect(foo).toEqual({ tag: 'Ok', value: [ { NAME: 'Float', VAL: 0} ]})
+    })
+    test("mm(0,0,[0,0,0])", () => {
+      let foo = run("mm(0,0,[0,0,0])")
+      expect(foo).toEqual({ "tag": "Error", "value": "Function multimodal error: Too many weights provided" })
     })
 });

--- a/packages/squiggle-lang/src/rescript/interpreter/typeSystem/HardcodedFunctions.res
+++ b/packages/squiggle-lang/src/rescript/interpreter/typeSystem/HardcodedFunctions.res
@@ -125,8 +125,10 @@ module Multimodal = {
         ->E.R.bind(TypeSystem.TypedValue.toArray)
         ->E.R.bind(r => r |> E.A.fmap(TypeSystem.TypedValue.toFloat) |> E.A.R.firstErrorOrOpen)
 
-      E.R.merge(dists, weights) |> E.R.fmap(((a, b)) =>
-        E.A.zipMaxLength(a, b) |> E.A.fmap(((a, b)) => (a |> E.O.toExn(""), b |> E.O.default(1.0)))
+        E.R.merge(dists, weights) -> E.R.bind(((a, b)) =>
+          E.A.length(b) > E.A.length(a) ?
+            Error("Too many weights provided") :
+            Ok(E.A.zipMaxLength(a, b) |> E.A.fmap(((a, b)) => (a |> E.O.toExn(""), b |> E.O.default(1.0))))
       )
     | _ => Error("Needs items")
     }


### PR DESCRIPTION
This fixes the following types of strings crashing:

`mm(0,0,[0,0,0])`

With a test to catch that I succeeded in the fix