### PR TITLE
Remove unnecessary log

### DIFF
--- a/packages/squiggle-lang/src/rescript/parser/Parser.res
+++ b/packages/squiggle-lang/src/rescript/parser/Parser.res
@@ -297,7 +297,6 @@ let fromString2 = str => {
   )
 
   let value = E.R.bind(mathJsParse, MathAdtToDistDst.run)
-  Js.log2(mathJsParse, value)
   value
 }
 


### PR DESCRIPTION
A tiny, uncontroversial pull request, removing a console.log line that peppers outputs for no reason and doesn't need to be there