### PR TITLE
Fix test failure errors

### DIFF
--- a/packages/squiggle-lang/.gitignore
+++ b/packages/squiggle-lang/.gitignore
@@ -14,5 +14,6 @@ yarn-error.log
 .netlify
 .idea
 *.gen.ts
+*.gen.tsx
 *.gen.js
 dist

--- a/packages/squiggle-lang/tsconfig.json
+++ b/packages/squiggle-lang/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "jsx": "react",
     "allowJs": true,
     "noImplicitAny": true,
     "removeComments": true,


### PR DESCRIPTION
This fixes the following jsx errors Umur was getting with build:
```
src/js/index.ts:1:22 - error TS6142: Module '../rescript/ProgramEvaluator.gen' was resolved to '/home/umur/workspaces/hightechmind2020/upw
ork/squiggle.fork/packages/squiggle-lang/src/rescript/ProgramEvaluator.gen.tsx', but '--jsx' is not set.
   1 import {runAll} from '../rescript/ProgramEvaluator.gen';
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   src/js/index.ts:2:64 - error TS6142: Module '../rescript/ProgramEvaluator.gen' was resolved to '/home/umur/workspaces/hightechmind2020/upw
ork/squiggle.fork/packages/squiggle-lang/src/rescript/ProgramEvaluator.gen.tsx', but '--jsx' is not set.
   2 import type { Inputs_SamplingInputs_t as SamplingInputs } from '../rescript/ProgramEvaluator.gen';
                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   src/js/index.ts:4:34 - error TS6142: Module '../rescript/pointSetDist/DistPlus.gen' was resolved to '/home/umur/workspaces/hightechmind202
0/upwork/squiggle.fork/packages/squiggle-lang/src/rescript/pointSetDist/DistPlus.gen.tsx', but '--jsx' is not set.
   4 export type {t as DistPlus} from '../rescript/pointSetDist/DistPlus.gen';
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
Just need to specify that I want jsx in typescript by default, (and to ignore .gen.tsx files for git). This is what was missing from #60 that I probably should have committed with that PR