### PR TITLE
Made playground its own page

### DIFF
--- a/packages/website/docs/Playground.mdx
+++ b/packages/website/docs/Playground.mdx
@@ -1,7 +1,0 @@
----
-sidebar_position: 2
----
-
-import { SquigglePlayground } from "../src/components/SquigglePlayground";
-
-<SquigglePlayground initialSquiggleString="normal(0,1)" />

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -79,12 +79,7 @@ const config = {
             label: "Documentation",
           },
           { to: "/blog", label: "Blog", position: "left" },
-          {
-            type: "doc",
-            docId: "Playground",
-            label: "Playground",
-            position: "left",
-          },
+          { to: "/playground", label: "Playground", position: "left" },
           {
             href: "https://github.com/QURIresearch/squiggle",
             label: "GitHub",

--- a/packages/website/sidebars.js
+++ b/packages/website/sidebars.js
@@ -21,11 +21,6 @@ const sidebars = {
       label: "Introduction",
     },
     {
-      type: "doc",
-      id: "Playground",
-      label: "Playground",
-    },
-    {
       type: "category",
       label: "Features",
       items: [

--- a/packages/website/src/pages/playground.js
+++ b/packages/website/src/pages/playground.js
@@ -1,0 +1,20 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import { SquigglePlayground } from "../components/SquigglePlayground";
+
+export default function PlaygroundPage() {
+  return (
+    <Layout title="Playground" description="Squiggle Playground">
+      <div
+        style={{
+          maxWidth: 2000,
+          paddingTop: "3em",
+          margin: "0 auto",
+        }}
+      >
+        <h2> Squiggle Playground </h2>
+        <SquigglePlayground initialSquiggleString="normal(0,1)" />
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Very small change to make the playground its own page, different to being part of the documentation. (I think this will become increasingly useful as functionality is added)

This allows it to be much larger on the page.

<img width="2518" alt="image" src="https://user-images.githubusercontent.com/377065/162651830-ff593904-daee-43a4-b1f5-23dc3f79f850.png">
